### PR TITLE
Issue-18/Models reinitialized without editable_attributes

### DIFF
--- a/config/initializers/hotsheet/editable_attributes.rb
+++ b/config/initializers/hotsheet/editable_attributes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Rails.application.config.after_initialize do # rubocop:disable Metrics/BlockLength
+Rails.application.config.to_prepare do # rubocop:disable Metrics/BlockLength
   # Only run this initializer when running the Rails server
   next unless Rails.env.test? || defined? Rails::Server
 


### PR DESCRIPTION
[Issue 18](https://github.com/renuo/hotsheet/issues/18)

**Description**

- Found that the problem was associated to the moment the (editable_attributes) was defined and when the models being reloaded In dev mode, so as we reload the models in every change, and  because of the dynamic nature of editable attributes, the same were removed during each reload, until we restart the server.
- In order to avoid this behaviour  I add the method to_prepare, in order to reload everytime the models got reloaded.

I used these resources :
[Initialization-events](https://guides.rubyonrails.org/configuring.html#initialization-events)
[Boot load reloadable](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#use-case-1-during-boot-load-reloadable-code)

How it looks working: 

https://github.com/user-attachments/assets/03cda500-9918-41c4-bcec-264b9f207a4b

