### PR TITLE
Reset model configuration

### DIFF
--- a/lib/hotsheet.rb
+++ b/lib/hotsheet.rb
@@ -3,9 +3,9 @@
 require "sprockets/railtie"
 require "turbo-rails"
 
-require "hotsheet/configuration"
 require "hotsheet/engine"
 require "hotsheet/version"
+require "hotsheet/configuration"
 
 module Hotsheet
   class Error < StandardError; end
@@ -16,6 +16,7 @@ module Hotsheet
     end
 
     def configure
+      @configuration = Configuration.new
       yield configuration
     end
 

--- a/lib/hotsheet/configuration.rb
+++ b/lib/hotsheet/configuration.rb
@@ -6,6 +6,10 @@ module Hotsheet
 
     config_accessor(:models) { {} }
 
+    def initialize
+      self.models = {}
+    end
+
     def model(name, &block)
       model_config = ModelConfig.new
       yield model_config if block

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -7,7 +7,7 @@ require "rails/all"
 
 Bundler.require(*Rails.groups)
 
-module Lw2024DemoProject
+module HotsheetDummy
   class Application < Rails::Application
     config.load_defaults Rails::VERSION::STRING.to_f
   end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -3,18 +3,37 @@
 require "spec_helper"
 
 RSpec.describe "Hotsheet::Configuration" do
-  let(:config) do
-    Hotsheet.configure do |config|
-      config.model :Author do |model|
-        model.included_attributes = %i[name birthdate]
-        model.excluded_attributes = %i[created_at]
-      end
+  subject(:config) { Hotsheet.configuration }
+
+  context "without model configuration" do
+    before { Hotsheet.configure {} } # rubocop:disable Lint/EmptyBlock
+
+    it "does NOT have any configured model" do
+      expect(config.models).to eq({})
     end
   end
 
-  it "has included and excluded attributes" do
-    expect(config).to be_a Hotsheet::Configuration::ModelConfig
-    expect(config.included_attributes).to eq %i[name birthdate]
-    expect(config.excluded_attributes).to eq %i[created_at]
+  context "with a model configuration" do
+    let(:model_config) { config.models["Author"] }
+
+    before do
+      Hotsheet.configure do |config|
+        config.model :Author do |model|
+          model.included_attributes = %i[name birthdate]
+          model.excluded_attributes = %i[created_at]
+        end
+      end
+    end
+
+    it "stores a list of configured models" do
+      expect(config.models.length).to eq 1
+      expect(config.models["Author"]).to be_a Hotsheet::Configuration::ModelConfig
+    end
+
+    it "has included and excluded attributes" do
+      expect(model_config).to be_a Hotsheet::Configuration::ModelConfig
+      expect(model_config.included_attributes).to eq %i[name birthdate]
+      expect(model_config.excluded_attributes).to eq %i[created_at]
+    end
   end
 end


### PR DESCRIPTION
Issue:
```rb
hotsheet-dummy(dev)> Hotsheet.models.length
=> 4
hotsheet-dummy(dev)> Hotsheet.configure { }
{"Author"=>#<Hotsheet::Configuration::ModelConfig:0x000000010ff72d98 @included_attributes=[:name, :birthdate, :gender, :created_at]>,
 "Post"=>#<Hotsheet::Configuration::ModelConfig:0x000000010ff72c30 @excluded_attributes=[:id, :author_id, :created_at, :updated_at]>,
 "TableNameTest"=>#<Hotsheet::Configuration::ModelConfig:0x000000010ff72b68 @included_attributes=[]>,
 "VeryLongModelNameForOverflowTest"=>#<Hotsheet::Configuration::ModelConfig:0x000000010ff72ac8>}
=> nil
hotsheet-dummy(dev)> Hotsheet.models.length
=> 4
```