### PR TITLE
Compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- ## [Unreleased](https://github.com/renuo/hotsheet/compare/v0.1.0..HEAD) -->
 
+## [0.1.2](https://github.com/renuo/hotsheet/releases/tag/v0.1.2) (2025-02-03)
+
+- Remove sprockets as a dependency
+- Improve compatibility with multiple configurations of pagy
+
 ## [0.1.1](https://github.com/renuo/hotsheet/releases/tag/v0.1.1) (2025-02-03)
 
 - Improve configuration file usage and logic ([@simon-isler])

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gemspec
 
+group :development, :test do
+  gem "sprockets-rails"
+end
+
 group :test do
   gem "appraisal"
   gem "better_errors"

--- a/config/initializers/hotsheet/pagy.rb
+++ b/config/initializers/hotsheet/pagy.rb
@@ -4,4 +4,3 @@ require "pagy"
 
 # Pagy Variables (https://ddnexus.github.io/pagy/docs/api/pagy#variables)
 Pagy::DEFAULT[:limit] = 100
-Pagy::DEFAULT.freeze

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -5,6 +5,10 @@ source "https://rubygems.org"
 gem "rails", "~> 7.0.0"
 gem "concurrent-ruby", "1.3.4"
 
+group :development, :test do
+  gem "sprockets-rails"
+end
+
 group :test do
   gem "appraisal"
   gem "better_errors"

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,10 +1,9 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.1.0)
+    hotsheet (0.1.2)
       pagy
       rails (>= 6.1.0)
-      sprockets-rails
       stimulus-rails
       turbo-rails
 
@@ -318,6 +317,7 @@ DEPENDENCIES
   renuocop
   rspec-rails
   selenium-webdriver
+  sprockets-rails
   sqlite3 (~> 1.4)
 
 BUNDLED WITH

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.1.0"
 
+group :development, :test do
+  gem "sprockets-rails"
+end
+
 group :test do
   gem "appraisal"
   gem "better_errors"

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,10 +1,9 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.1.0)
+    hotsheet (0.1.2)
       pagy
       rails (>= 6.1.0)
-      sprockets-rails
       stimulus-rails
       turbo-rails
 
@@ -372,6 +371,7 @@ DEPENDENCIES
   renuocop
   rspec-rails
   selenium-webdriver
+  sprockets-rails
   sqlite3 (~> 1.4)
 
 BUNDLED WITH

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.2.0"
 
+group :development, :test do
+  gem "sprockets-rails"
+end
+
 group :test do
   gem "appraisal"
   gem "better_errors"

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,10 +1,9 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.1.0)
+    hotsheet (0.1.2)
       pagy
       rails (>= 6.1.0)
-      sprockets-rails
       stimulus-rails
       turbo-rails
 
@@ -331,6 +330,7 @@ DEPENDENCIES
   renuocop
   rspec-rails
   selenium-webdriver
+  sprockets-rails
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gem "rails", "8.0.0.rc2"
 
+group :development, :test do
+  gem "sprockets-rails"
+end
+
 group :test do
   gem "appraisal"
   gem "better_errors"

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,10 +1,9 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.1.0)
+    hotsheet (0.1.2)
       pagy
       rails (>= 6.1.0)
-      sprockets-rails
       stimulus-rails
       turbo-rails
 
@@ -367,6 +366,7 @@ DEPENDENCIES
   renuocop
   rspec-rails
   selenium-webdriver
+  sprockets-rails
   sqlite3
 
 BUNDLED WITH

--- a/hotsheet.gemspec
+++ b/hotsheet.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
   spec.add_dependency "rails", ">= 6.1.0"
   spec.add_dependency "pagy"
-  spec.add_dependency "sprockets-rails"
   spec.add_dependency "stimulus-rails"
   spec.add_dependency "turbo-rails"
 end

--- a/lib/hotsheet.rb
+++ b/lib/hotsheet.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "sprockets/railtie"
 require "turbo-rails"
 
 require "hotsheet/engine"

--- a/lib/hotsheet/engine.rb
+++ b/lib/hotsheet/engine.rb
@@ -4,6 +4,8 @@ module Hotsheet
   class Engine < ::Rails::Engine
     isolate_namespace Hotsheet
 
-    config.assets.precompile += %w[hotsheet/application.css hotsheet/application.js]
+    initializer "hotsheet.assets" do |app|
+      app.config.assets.precompile += %w[hotsheet/application.css hotsheet/application.js]
+    end
   end
 end

--- a/lib/hotsheet/version.rb
+++ b/lib/hotsheet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hotsheet
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -9,7 +9,6 @@ Rails.application.configure do
   config.active_storage.service = :test
   config.active_support.deprecation = :stderr
   config.active_support.report_deprecations = true
-  config.assets.quiet = true
   config.cache_store = :null_store
   config.consider_all_requests_local = true
   config.eager_load = false


### PR DESCRIPTION
We currently support only sprockets projects, in this MR I intend to get rid of that dependency and allow other tools such as CSS/JS bundling and importmaps

- Move Sprockets dependency into development and test environments only.
- Avoid configuration-collisions for Pagy. Considering to remove the gem as a dependency altogether.