### PR TITLE
Fix I18n fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- ## [Unreleased](https://github.com/renuo/hotsheet/compare/v0.1.0..HEAD) -->
 
+## [0.2.1](https://github.com/renuo/hotsheet/releases/tag/v0.2.1) - 2025-06-27
+
+- Fix I18n fallback ([@hunchr])
+
 ## [0.2.0](https://github.com/renuo/hotsheet/releases/tag/v0.2.0) - 2025-06-25
 
 - Add dark mode and improve CSS ([@hunchr])

--- a/app/controllers/hotsheet/sheets_controller.rb
+++ b/app/controllers/hotsheet/sheets_controller.rb
@@ -28,15 +28,15 @@ class Hotsheet::SheetsController < Hotsheet::ApplicationController
 
   def set_column
     @column = @sheet.columns[params[:column_name]]
-    return respond Hotsheet.t "errors.not_found" if @column.nil?
+    return respond Hotsheet.t "error_not_found" if @column.nil?
 
-    respond Hotsheet.t "errors.forbidden" unless @column.editable?
+    respond Hotsheet.t "error_forbidden" unless @column.editable?
   end
 
   def set_resource
     @resource = @sheet.model.find_by id: params[:id]
 
-    respond Hotsheet.t "errors.not_found" if @resource.nil?
+    respond Hotsheet.t "error_not_found" if @resource.nil?
   end
 
   def respond(message = "")

--- a/app/views/hotsheet/home/error.html.erb
+++ b/app/views/hotsheet/home/error.html.erb
@@ -1,1 +1,1 @@
-<h1><%= Hotsheet.t "errors.not_found" %></h1>
+<h1><%= Hotsheet.t "error_not_found" %></h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,5 @@
 en:
   hotsheet:
-    errors:
-      forbidden: Forbidden
-      not_found: Not found
+    error_forbidden: Forbidden
+    error_not_found: Not found
     title: Hotsheet

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.2.0)
+    hotsheet (0.2.1)
       rails (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.2.0)
+    hotsheet (0.2.1)
       rails (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.2.0)
+    hotsheet (0.2.1)
       rails (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.2.0)
+    hotsheet (0.2.1)
       rails (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hotsheet (0.2.0)
+    hotsheet (0.2.1)
       rails (>= 6.1.0)
 
 GEM

--- a/hotsheet.gemspec
+++ b/hotsheet.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     "rubygems_mfa_required" => "true"
   }
   s.files = Dir["app/{assets,controllers,helpers,views}/**/*.*",
-                "{config,lib}/**/*.rb", "LICENSE", "README.md"]
+                "{config,lib}/**/*.*", "LICENSE", "README.md"]
 
   s.required_ruby_version = ">= 3.1.0"
   s.add_dependency "rails", ">= 6.1.0"

--- a/lib/hotsheet.rb
+++ b/lib/hotsheet.rb
@@ -12,9 +12,9 @@ module Hotsheet
   class << self
     include Config
 
-    CONFIG = {}.freeze
-
     attr_reader :config
+
+    CONFIG = {}.freeze
 
     def configure(config = {}, &sheets)
       @config = [merge_config!(CONFIG, config), sheets]
@@ -29,10 +29,10 @@ module Hotsheet
       end
     end
 
+    I18N = Psych.load_file(Hotsheet::Engine.root.join("config/locales/en.yml"))["en"]["hotsheet"].freeze
+
     def t(key)
-      I18n.t key, scope: "hotsheet"
-    rescue I18n::MissingTranslationData
-      I18n.with_locale(:en) { I18n.t key, scope: "hotsheet" }
+      I18n.t "hotsheet.#{key}", default: I18N[key]
     end
 
     private

--- a/lib/hotsheet/version.rb
+++ b/lib/hotsheet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hotsheet
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/lib/hotsheet_spec.rb
+++ b/spec/lib/hotsheet_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hotsheet do
 
   describe "#t" do
     it "falls back to english" do
-      expect { I18n.with_locale(:de) { described_class.t "errors.not_found" } }.not_to raise_error
+      expect { I18n.with_locale(:de) { described_class.t "error_not_found" } }.not_to raise_error
     end
   end
 end

--- a/spec/requests/hotsheet/home_controller_spec.rb
+++ b/spec/requests/hotsheet/home_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hotsheet::HomeController do
     it "shows an error page" do
       get "/hotsheet/invalid/route"
       expect(response).to be_not_found
-      expect(response.body).to include I18n.t("hotsheet.errors.not_found")
+      expect(response.body).to include Hotsheet.t("error_not_found")
     end
   end
 end

--- a/spec/requests/hotsheet/sheets_controller_spec.rb
+++ b/spec/requests/hotsheet/sheets_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hotsheet::SheetsController do
       it "shows an error page" do
         get "/hotsheet/authors"
         expect(response).to be_not_found
-        expect(response.body).to include I18n.t("hotsheet.errors.not_found")
+        expect(response.body).to include Hotsheet.t("error_not_found")
       end
     end
   end

--- a/spec/requests/hotsheet/sheets_controller_spec.rb
+++ b/spec/requests/hotsheet/sheets_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Hotsheet::SheetsController do
 
       it "does not update the resource" do
         expect { put path, params: { column_name: :name, value: "Bob" } }.not_to change(user, :reload)
-        expect(response.parsed_body).to eq I18n.t("hotsheet.errors.forbidden")
+        expect(response.parsed_body).to eq Hotsheet.t("error_forbidden")
       end
     end
 
@@ -55,21 +55,21 @@ RSpec.describe Hotsheet::SheetsController do
 
       it "does not update the resource" do
         expect { put path, params: { column_name: :name, value: "Bob" } }.not_to change(user, :reload)
-        expect(response.parsed_body).to eq I18n.t("hotsheet.errors.not_found")
+        expect(response.parsed_body).to eq Hotsheet.t("error_not_found")
       end
     end
 
     context "with nonexistent column" do
       it "does not update the resource" do
         expect { put path, params: { column_name: :age, value: 21 } }.not_to change(user, :reload)
-        expect(response.parsed_body).to eq I18n.t("hotsheet.errors.not_found")
+        expect(response.parsed_body).to eq Hotsheet.t("error_not_found")
       end
     end
 
     context "with missing params" do
       it "does not update the resource" do
         expect { put path }.not_to change(user, :reload)
-        expect(response.parsed_body).to eq I18n.t("hotsheet.errors.not_found")
+        expect(response.parsed_body).to eq Hotsheet.t("error_not_found")
       end
     end
   end


### PR DESCRIPTION
- the locales yaml were not included in the gem
- the fallback used `:en`, but if `:en` is not included in `config.i18n.available_locales`, an error is raised. now, the locales are loaded directly from the file, so no additional locale needs to be added.