### PR TITLE
Add column-type text option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.2.3](https://github.com/renuo/hotsheet/releases/tag/v0.2.3) - 2026-05-21
 
-- Add text column type with auto-resizing textarea ([@oliver-thoma])
+- Add text column type with auto-resizing textarea ([@odthoma])
 
 ## [0.2.2](https://github.com/renuo/hotsheet/releases/tag/v0.2.2) - 2025-07-04
 
@@ -28,18 +28,18 @@
 ## [0.1.1](https://github.com/renuo/hotsheet/releases/tag/v0.1.1) - 2025-02-03
 
 - Form inputs are now always visible for usage simplicity ([@ignaciosy])
-- Improve configuration file usage and logic ([@simon-isler])
+- Improve configuration file usage and logic ([@sislr])
 - Improve flash messages layout ([@ignaciosy])
 
 ## [0.1.0](https://github.com/renuo/hotsheet/releases/tag/v0.1.0) - 2024-11-08
 
 - Gem structure and initial configuration ([@ignaciosy])
 - Generator for initializer and mounting engine in routes ([@hunchr])
-- Inline editing table ([@simon-isler], [@edmunteanu])
+- Inline editing table ([@sislr], [@edmunteanu])
 - Pagination for data tables ([@hunchr])
 
 [@edmunteanu]: https://github.com/edmunteanu
-[@oliver-thoma]: https://github.com/oliver-thoma
+[@odthoma]: https://github.com/odthoma
 [@hunchr]: https://github.com/hunchr
 [@ignaciosy]: https://github.com/ignaciosy
-[@simon-isler]: https://github.com/simon-isler
+[@sislr]: https://github.com/sislr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-<!-- ## [Unreleased](https://github.com/renuo/hotsheet/compare/v0.2.1..HEAD) -->
+## [0.2.3](https://github.com/renuo/hotsheet/releases/tag/v0.2.3) - 2026-05-21
+
+- Add text column type with auto-resizing textarea ([@oliver-thoma])
 
 ## [0.2.2](https://github.com/renuo/hotsheet/releases/tag/v0.2.2) - 2025-07-04
 
@@ -37,6 +39,7 @@
 - Pagination for data tables ([@hunchr])
 
 [@edmunteanu]: https://github.com/edmunteanu
+[@oliver-thoma]: https://github.com/oliver-thoma
 [@hunchr]: https://github.com/hunchr
 [@ignaciosy]: https://github.com/ignaciosy
 [@simon-isler]: https://github.com/simon-isler

--- a/app/javascripts/controllers/sheets_controller.ts
+++ b/app/javascripts/controllers/sheets_controller.ts
@@ -7,6 +7,7 @@ export class SheetsController extends Controller {
 
   private flash = document.querySelector(".flash")!
   private input = document.createElement("input")
+  private textarea = document.createElement("textarea")
   private columns = this.element.querySelectorAll(".column")
   private cell = this.input as HTMLElement
   private cells: Record<string, HTMLElement> = {}
@@ -18,15 +19,13 @@ export class SheetsController extends Controller {
   /** Sends the new value to the server. */
   private readonly update = () => {
     const [x, y] = this.getPosition()
-    const {
-      cell,
-      prevValue,
-      input: { value },
-    } = this
+    const { cell, prevValue } = this
+    const value = this.isText(x) ? this.textarea.value : this.input.value
 
     if (value === prevValue) return
 
-    fetch(`${location.pathname}/${this.ids[y]}?column_name=${this.columnNames[x]}&value=${value}`, {
+    const params = new URLSearchParams({ column_name: this.columnNames[x], value })
+    fetch(`${location.pathname}/${this.ids[y]}?${params}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -52,16 +51,25 @@ export class SheetsController extends Controller {
   /** Returns the position of the focused cell. */
   private readonly getPosition = (): number[] => this.cell.dataset.xy!.split(",").map(Number)
 
+  private readonly isText = (x: number): boolean =>
+    this.columns[x]?.getAttribute("data-type") === "text"
+
   /** Sets the cell and focuses it. */
   private readonly setCell = (cell?: HTMLElement): void => {
-    if (!cell) return
     if (this.editMode) {
+      const [x] = this.getPosition()
+      const isText = this.isText(x)
       this.update()
       this.editMode = false
-      this.cell.innerHTML = this.input.value
-      this.cell.scrollLeft = 0
+      if (isText) {
+        this.cell.textContent = this.textarea.value
+      } else {
+        this.cell.innerHTML = this.input.value
+        this.cell.scrollLeft = 0
+      }
     }
 
+    if (!cell) return
     this.cell = cell
     cell.focus()
   }
@@ -69,10 +77,13 @@ export class SheetsController extends Controller {
   /** Enables edit mode for the focused cell. */
   private readonly enableEditMode = (): void => {
     if (!this.cell.classList.contains("readonly")) {
+      const [x] = this.getPosition()
+      const isText = this.isText(x)
+      const editor = isText ? this.textarea : this.input
       this.editMode = true
-      this.prevValue = this.input.value = this.cell.innerHTML
-      this.cell.replaceChildren(this.input)
-      this.input.select()
+      this.prevValue = editor.value = isText ? (this.cell.textContent ?? "") : this.cell.innerHTML
+      this.cell.replaceChildren(editor)
+      editor.select()
     }
   }
 
@@ -95,7 +106,9 @@ export class SheetsController extends Controller {
       if (key === "Enter") {
         const [x, y] = this.getPosition()
 
-        this.setCell(this.cells[`${x},${y + 1}`])
+        if (!this.isText(x)) {
+          this.setCell(this.cells[`${x},${y + 1}`])
+        }
       }
     } else if (key === "Enter") {
       this.enableEditMode()
@@ -139,6 +152,9 @@ export class SheetsController extends Controller {
     this.columnNames = [...this.element.querySelectorAll<HTMLElement>(".header")].map(
       (header) => header.dataset.name!,
     )
+    this.element.addEventListener("focusout", (event: FocusEvent) => {
+      if (!this.element.contains(event.relatedTarget as Node)) this.setCell()
+    })
     this.addCells()
   }
 

--- a/app/javascripts/controllers/sheets_controller.ts
+++ b/app/javascripts/controllers/sheets_controller.ts
@@ -80,6 +80,7 @@ export class SheetsController extends Controller {
       const [x] = this.getPosition()
       const isText = this.isText(x)
       const editor = isText ? this.textarea : this.input
+      if (isText) this.textarea.style.height = ""
       this.editMode = true
       this.prevValue = editor.value = isText ? (this.cell.textContent ?? "") : this.cell.innerHTML
       this.cell.replaceChildren(editor)

--- a/app/stylesheets/table.css
+++ b/app/stylesheets/table.css
@@ -78,7 +78,7 @@
   }
 
   textarea {
-    min-height: calc(var(--height) * 4);
+    field-sizing: content;
     resize: vertical;
     white-space: pre-wrap;
     width: 100%;

--- a/app/stylesheets/table.css
+++ b/app/stylesheets/table.css
@@ -61,6 +61,30 @@
   }
 }
 
+.column[data-type="text"] {
+  max-width: 40rem;
+
+  .cell:not(.header):not(:has(textarea)) {
+    display: block;
+    line-height: var(--height);
+    text-overflow: ellipsis;
+  }
+
+  .cell:not(.header):has(textarea) {
+    align-items: flex-start;
+    height: auto;
+    min-height: var(--height);
+    padding: 0.25rem 0.5rem;
+  }
+
+  textarea {
+    min-height: calc(var(--height) * 4);
+    resize: vertical;
+    white-space: pre-wrap;
+    width: 100%;
+  }
+}
+
 .load-more {
   align-items: center;
   background-color: var(--color-border);

--- a/app/views/hotsheet/sheets/index.html.erb
+++ b/app/views/hotsheet/sheets/index.html.erb
@@ -4,7 +4,7 @@
       <% column_name, column = entry %>
       <% editable = column.editable? %>
 
-      <div class="column">
+      <div class="column"<% if column.type %> data-type="<%= column.type %>"<% end %>>
         <span class="cell header" data-name="<%= column_name %>">
           <%= @sheet.model.human_attribute_name column_name %>
         </span>

--- a/lib/hotsheet/column.rb
+++ b/lib/hotsheet/column.rb
@@ -7,6 +7,7 @@ class Hotsheet::Column
 
   CONFIG = {
     editable: { allowed_classes: [FalseClass, Proc], default: true },
+    type: { allowed_classes: [Symbol], default: nil },
     visible: { allowed_classes: [FalseClass, Proc], default: true }
   }.freeze
 
@@ -16,6 +17,10 @@ class Hotsheet::Column
 
   def editable?
     is? :editable
+  end
+
+  def type
+    @config[:type]
   end
 
   def visible?

--- a/lib/hotsheet/version.rb
+++ b/lib/hotsheet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hotsheet
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/dummy/config/initializers/hotsheet.rb
+++ b/spec/dummy/config/initializers/hotsheet.rb
@@ -3,7 +3,7 @@
 Hotsheet.configure do
   sheet :Post, per: 10 do
     column :title
-    column :body
+    column :body, type: :text
     column :user_id
     column :created_at
     column :updated_at, editable: false

--- a/spec/lib/hotsheet/column_spec.rb
+++ b/spec/lib/hotsheet/column_spec.rb
@@ -6,9 +6,18 @@ RSpec.describe Hotsheet::Column do
   let(:column) { described_class.new config }
   let(:config) { {} }
 
-  it "is editable and visible by default" do
+  it "is editable and visible by default, with no type" do
     expect(column.editable?).to be true
     expect(column.visible?).to be true
+    expect(column.type).to be_nil
+  end
+
+  context "with type: :text" do
+    let(:config) { { type: :text } }
+
+    it "exposes the type" do
+      expect(column.type).to eq :text
+    end
   end
 
   context "with config" do

--- a/spec/requests/hotsheet/sheets_controller_spec.rb
+++ b/spec/requests/hotsheet/sheets_controller_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Hotsheet::SheetsController do
       expect(response.body).to have_no_css ".load-more"
     end
 
+    context "with a text column" do
+      let(:config) { Hotsheet.configure { sheet(:User) { column :name, type: :text } } }
+
+      it "renders the column with data-type attribute" do
+        get hotsheet.sheets_path :users
+        expect(response.body).to have_css ".column[data-type='text']"
+      end
+    end
+
     context "with :per configured" do
       let(:config) { Hotsheet.configure { sheet(:User, per: 1) { column :name } } }
       let!(:other_user) { User.create!(name: "2nd Page", handle: "2", email: "2nd@local", admin: false) }

--- a/spec/system/hotsheet/sheets_controller_spec.rb
+++ b/spec/system/hotsheet/sheets_controller_spec.rb
@@ -16,4 +16,25 @@ RSpec.describe Hotsheet::SheetsController do
     expect { find(".cell", text: user.email).click }
       .to change { user.reload.name }.from("Admin User").to "Admin"
   end
+
+  context "with a text column" do
+    before do
+      prepare do
+        Hotsheet.configure do
+          sheet(:User) do
+            column :name, type: :text
+            column :email
+          end
+        end
+      end
+    end
+
+    it "updates the cell value with a newline" do
+      visit hotsheet.sheets_path :users
+      find(".cell", text: user.name).click.send_keys(:enter).fill_in(with: "Line 1\nLine 2")
+
+      expect { find(".cell", text: user.email).click }
+        .to change { user.reload.name }.from("Admin User").to "Line 1\nLine 2"
+    end
+  end
 end

--- a/spec/system/hotsheet/sheets_controller_spec.rb
+++ b/spec/system/hotsheet/sheets_controller_spec.rb
@@ -11,10 +11,15 @@ RSpec.describe Hotsheet::SheetsController do
 
   it "updates the cell value" do
     visit hotsheet.sheets_path :users
-    find(".cell", text: user.name).click.send_keys(:enter).fill_in(with: "Admin").send_keys :enter
 
-    expect { find(".cell", text: user.email).click }
-      .to change { user.reload.name }.from("Admin User").to "Admin"
+    find(".cell", text: user.name)
+      .click
+      .send_keys(:enter)
+      .fill_in(with: "Admin")
+      .send_keys(:enter)
+
+    expect(page).to have_css(".cell", text: "Admin")
+    expect(user.reload.name).to eq("Admin")
   end
 
   context "with a text column" do
@@ -31,10 +36,14 @@ RSpec.describe Hotsheet::SheetsController do
 
     it "updates the cell value with a newline" do
       visit hotsheet.sheets_path :users
-      find(".cell", text: user.name).click.send_keys(:enter).fill_in(with: "Line 1\nLine 2")
 
-      expect { find(".cell", text: user.email).click }
-        .to change { user.reload.name }.from("Admin User").to "Line 1\nLine 2"
+      find(".cell", text: user.name)
+        .click
+        .send_keys(:enter)
+        .fill_in(with: "Line 1\nLine 2")
+
+      find(".cell", text: user.email).click
+      expect(user.reload.name).to eq("Line 1\nLine 2")
     end
   end
 end


### PR DESCRIPTION
TICKET-25767

This PR adds a type option to the column configuration. Columns can now be configured with `type: :text` to better handle multi-line content

```rb
column :body, type: :text
```

This is how it behaves:

https://github.com/user-attachments/assets/e1ee9734-7b97-4357-8024-e3223726c64c
